### PR TITLE
or1k: Enable use of C functions in libgloss

### DIFF
--- a/gcc/config/or1k/or1k.h
+++ b/gcc/config/or1k/or1k.h
@@ -74,7 +74,7 @@ Boston, MA 02111-1307, USA.  */
 		             %{!p:%{!pg:-lc}}%{p:-lc_p}%{pg:-lc_p}}"			\
                  "%{mnewlib:%{!g:-lc} %{g:-lg} -lor1k					\
                             %{mboard=*:-lboard-%*} %{!mboard=*:-lboard-or1ksim}		\
-                            %{!g:-lc} %{g:-lg}						\
+                            %{!g:-lc} -lor1k %{g:-lg}						\
                             }"
 
 /* Target machine storage layout */


### PR DESCRIPTION
Although it might seem a bit creepy, it may in some cases be necessary
to use standard C functions in libgloss, for example to use malloc in
the multicore bootstrap process.

Therefore we need to add -lor1k also before -lc in the link order to
capture those dependencies.
