### PR TITLE
or1k: Add support for using the native atomics.

### DIFF
--- a/gcc/config/or1k/or1k-protos.h
+++ b/gcc/config/or1k/or1k-protos.h
@@ -44,6 +44,11 @@ extern void        or1k_emit_set_const32 (rtx  op0,
                                           rtx  op1);
 extern bool        or1k_expand_symbol_ref (enum machine_mode mode,
                                            rtx operands[]);
+extern void        or1k_expand_cmpxchg_qihi (rtx bval, rtx retval,
+                        rtx mem, rtx oldval, rtx newval, int is_weak,
+                        enum memmodel success_mode, enum memmodel failure_mode);
+extern void  or1k_expand_fetch_op_qihi (rtx oldval, rtx mem, rtx operand,
+                                        rtx newval, rtx (*generator)(rtx, rtx, rtx, rtx, rtx));
 #endif
 
 #endif

--- a/gcc/config/or1k/or1k.c
+++ b/gcc/config/or1k/or1k.c
@@ -400,6 +400,118 @@ or1k_expand_compare (enum rtx_code code, rtx op0, rtx op1)
 }	/* or1k_expand_compare () */
 
 
+/* TODO(bluecmd): Write documentation for this function */
+void
+or1k_expand_cmpxchg_qihi (rtx bval, rtx retval, rtx mem, rtx oldval, rtx newval,
+                          int is_weak, enum memmodel success_mode,
+                          enum memmodel failure_mode)
+{
+  rtx addr1 = force_reg (Pmode, XEXP (mem, 0));
+  rtx addr = gen_reg_rtx (Pmode);
+  rtx off = gen_reg_rtx (SImode);
+  rtx shifter = gen_reg_rtx (SImode);
+  rtx retword = gen_reg_rtx (SImode);
+  rtx mask = gen_reg_rtx (SImode);
+  rtx shifted_oldval = gen_reg_rtx (SImode);
+  rtx shifted_newval = gen_reg_rtx (SImode);
+  rtx shifted_mask = gen_reg_rtx (SImode);
+  rtx mask_const;
+  rtx memsi;
+  enum machine_mode mode = GET_MODE (mem);
+
+  oldval = gen_lowpart_common (SImode, oldval);
+  newval = gen_lowpart_common (SImode, newval);
+
+  mask_const = gen_rtx_CONST_INT (VOIDmode,
+                                  mode == QImode ? 0xff : 0xffff);
+  emit_insn (gen_rtx_SET (VOIDmode, mask, mask_const));
+
+  /* align address and retrieve the offset. */
+  emit_insn (gen_rtx_SET (VOIDmode, addr,
+             gen_rtx_AND (Pmode, addr1, GEN_INT (-4))));
+  emit_insn (gen_rtx_SET (VOIDmode, off,
+             gen_rtx_AND (SImode, addr1, GEN_INT (3))));
+  emit_insn (gen_rtx_SET (VOIDmode, off,
+                          gen_rtx_XOR (SImode, off,
+                                       GEN_INT (GET_MODE (mem) == QImode
+                                                ? 3 : 2))));
+
+  memsi = gen_rtx_MEM (SImode, addr);
+
+  /* shift all arguments to be aligned to where the data we want
+   * to operate on is located. */
+  emit_insn (gen_rtx_SET (VOIDmode, shifter,
+             gen_rtx_ASHIFT (SImode, off, GEN_INT (3))));
+
+  emit_insn (gen_ashlsi3 (shifted_oldval, oldval, shifter));
+  emit_insn (gen_ashlsi3 (shifted_newval, newval, shifter));
+  emit_insn (gen_ashlsi3 (shifted_mask, mask, shifter));
+
+  emit_insn (gen_cmpxchg_mask (bval, retword, memsi, shifted_oldval,
+                               shifted_newval, shifted_mask));
+
+  /* shift the data we care about to the lower end. */
+  emit_insn (gen_lshrsi3 (retword, retword, shifter));
+
+  emit_move_insn (retval, gen_lowpart (GET_MODE (retval), retword));
+}
+
+/* TODO(bluecmd): Write documentation for this function */
+void
+or1k_expand_fetch_op_qihi (rtx oldval, rtx mem, rtx operand, rtx newval,
+                           rtx (*generator)(rtx, rtx, rtx, rtx, rtx))
+{
+  rtx addr1 = force_reg (Pmode, XEXP (mem, 0));
+  rtx addr = gen_reg_rtx (Pmode);
+  rtx off = gen_reg_rtx (SImode);
+  rtx shifter = gen_reg_rtx (SImode);
+  rtx mask = gen_reg_rtx (SImode);
+  rtx shifted_oldval = gen_reg_rtx (SImode);
+  rtx shifted_newval = gen_reg_rtx (SImode);
+  rtx shifted_operand = gen_reg_rtx (SImode);
+  rtx shifted_mask = gen_reg_rtx (SImode);
+  rtx mask_const;
+  rtx memsi;
+  enum machine_mode mode = GET_MODE (mem);
+
+  /* TODO(bluecmd): A lot of code is shared between cmpxchg and this. We should
+   * move it to nice functions. */
+  operand = gen_lowpart_common (SImode, operand);
+
+  mask_const = gen_rtx_CONST_INT (VOIDmode,
+                                  mode == QImode ? 0xff : 0xffff);
+  emit_insn (gen_rtx_SET (VOIDmode, mask, mask_const));
+
+  /* align address and retrieve the offset. */
+  emit_insn (gen_rtx_SET (VOIDmode, addr,
+             gen_rtx_AND (Pmode, addr1, GEN_INT (-4))));
+  emit_insn (gen_rtx_SET (VOIDmode, off,
+             gen_rtx_AND (SImode, addr1, GEN_INT (3))));
+  emit_insn (gen_rtx_SET (VOIDmode, off,
+                          gen_rtx_XOR (SImode, off,
+                                       GEN_INT (GET_MODE (mem) == QImode
+                                                ? 3 : 2))));
+
+  memsi = gen_rtx_MEM (SImode, addr);
+
+  /* shift all arguments to be aligned to where the data we want
+   * to operate on is located. */
+  emit_insn (gen_rtx_SET (VOIDmode, shifter,
+             gen_rtx_ASHIFT (SImode, off, GEN_INT (3))));
+
+  emit_insn (gen_ashlsi3 (shifted_operand, operand, shifter));
+  emit_insn (gen_ashlsi3 (shifted_mask, mask, shifter));
+
+  emit_insn (generator (shifted_oldval, memsi, shifted_operand,
+                        shifted_newval, shifted_mask));
+
+  /* shift the data we care about to the lower end. */
+  emit_insn (gen_lshrsi3 (shifted_oldval, shifted_oldval, shifter));
+  emit_insn (gen_lshrsi3 (shifted_newval, shifted_newval, shifter));
+  emit_move_insn (oldval, gen_lowpart (GET_MODE (oldval), shifted_oldval));
+  emit_move_insn (newval, gen_lowpart (GET_MODE (newval), shifted_newval));
+}
+
 /* -------------------------------------------------------------------------- */
 /*!Emit insns to use the l.cmov instruction
 


### PR DESCRIPTION
This adds support for the __sync and __atomics builtins for 1, 2 and 4
bytes of memory. Since the native instructions only protect a full word,
use 4 bytes where possible.
